### PR TITLE
Adding test coverage (simplecov)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /log/*
 !/log/.keep
 /tmp
+coverage
+

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
+  gem 'simplecov'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     debug_inspector (0.0.2)
+    docile (1.1.5)
     erubis (2.7.0)
     execjs (2.6.0)
     globalid (0.3.6)
@@ -112,6 +113,11 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    simplecov (0.11.1)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     spring (1.4.3)
     sprockets (3.4.0)
       rack (> 1, < 3)
@@ -147,6 +153,7 @@ DEPENDENCIES
   rails (= 4.2.4)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  simplecov
   spring
   sqlite3
   turbolinks

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,15 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+# save to CircleCI's artifacts directory if we're on CircleCI
+# view report at $BASE_URL/$BUILD_NUMBER#artifacts -- click index.html
+if ENV['CIRCLE_ARTIFACTS']
+  dir = File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
+  SimpleCov.coverage_dir(dir)
+end
+
+SimpleCov.start
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
[simplecov](https://github.com/colszowka/simplecov) tells you what code is and isn't covered by tests.  After running tests, open coverage/index.html to view the coverage report.
