### PR TITLE
Filtering Active Admin actions

### DIFF
--- a/app/controllers/offenses_controller.rb
+++ b/app/controllers/offenses_controller.rb
@@ -1,5 +1,6 @@
 class OffensesController < ApplicationController
   before_action :set_offense, only: [:show, :edit, :update, :destroy]
+  skip_before_action :authenticate_admin_user!, only: [:new, :create]
 
   # GET /offenses
   # GET /offenses.json

--- a/test/controllers/offenses_controller_test.rb
+++ b/test/controllers/offenses_controller_test.rb
@@ -8,18 +8,18 @@ class OffensesControllerTest < ActionController::TestCase
     @offense = offenses(:one)
   end
 
-  test "should get index" do
+  test 'should get index' do
     get :index
     assert_response :success
     assert_not_nil assigns(:offenses)
   end
 
-  test "should get new" do
+  test 'should get new' do
     get :new
     assert_response :success
   end
 
-  test "should create offense" do
+  test 'should create offense' do
     assert_difference('Offense.count') do
       post :create, offense: { }
     end
@@ -27,22 +27,22 @@ class OffensesControllerTest < ActionController::TestCase
     assert_redirected_to offense_path(assigns(:offense))
   end
 
-  test "should show offense" do
+  test 'should show offense' do
     get :show, id: @offense
     assert_response :success
   end
 
-  test "should get edit" do
+  test 'should get edit' do
     get :edit, id: @offense
     assert_response :success
   end
 
-  test "should update offense" do
+  test 'should update offense' do
     patch :update, id: @offense, offense: {ip_address: '127.0.0.3', host_name: 'teststring'}
     assert_redirected_to offense_path(assigns(:offense))
   end
 
-  test "should destroy offense" do
+  test 'should destroy offense' do
     assert_difference('Offense.count', -1) do
       delete :destroy, id: @offense
     end
@@ -50,4 +50,25 @@ class OffensesControllerTest < ActionController::TestCase
     assert_redirected_to offenses_path
   end
 
+  # probably will nix this and just expose :create eventually
+  test 'should not require authentication for "new"' do
+    sign_out admin_users(:one)
+    get :new
+    assert_response :success
+  end
+
+  test 'should not require authentication to create offense' do
+    sign_out admin_users(:one)
+    assert_difference('Offense.count') do
+      post :create, offense: { }
+    end
+
+    assert_redirected_to offense_path(assigns(:offense))
+  end
+
+  test 'should not show offense without authentication' do
+    sign_out admin_users(:one)
+    get :show, id: @offense
+    assert_response :redirect
+  end
 end

--- a/workalong.md
+++ b/workalong.md
@@ -8,8 +8,8 @@ http://guides.rubyonrails.org/command_line.html
 * `rails c` starts the interactive console
 
 ### Debugging
-We're using [byebug](https://github.com/deivid-rodriguez/byebug/blob/master/GUIDE.md) (see also
-http://edgeguides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-byebug-gem).
+We're using [byebug](https://github.com/deivid-rodriguez/byebug/blob/master/GUIDE.md) 
+(See also http://edgeguides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-byebug-gem).
 * place `byebug` anywhere in the code that you want to suspend execution
 
 ### Testing
@@ -44,11 +44,45 @@ http://edgeguides.rubyonrails.org/active_record_migrations.html
 * `rake db:test:prepare` runs against the test database
 
 ## Run tests
-* ` rake test`
+* `rake test`
 
 ## Modify the controller
 ### Strong parameters
 http://guides.rubyonrails.org/action_controller_overview.html#strong-parameters
 
 ## Run tests
-* ` rake test`
+* `rake test`
+
+# Active Admin
+The Active Admin gem provides authorization and authentication of users and administrators.  It uses Devise under the hood to administer users and even provides a UI component for user administration.
+
+We want to allow folks who are not registered to report offenses, but not to view, change or delete them. Nor do we want anyone to manually create an offense -- only if someone leaves their computer unsecured should an offense be created.
+
+## Add Active Admin to the project
+* add the Active Admin and Devise gems to the Gemfile
+```
+gem 'activeadmin', github: 'activeadmin'
+gem 'devise'
+```
+* run `bundle install`
+
+Often we do _not_ have to tell Bundler to get the gem from a GitHub repository, but we do here because we'reusing Rails 4 and there are dependency issues (explained on [the Active Admin README](https://github.com/activeadmin/activeadmin).
+
+## Install Active Admin
+Let's follow the rest of the instructions on [the Acive Acmin installation page](https://github.com/activeadmin/activeadmin/blob/master/docs/0-installation.md).  We've added the gem, but we now want to generate the rest of the code that we need to use it (also not something we do for most gems we use) and create database objects and data.
+
+### Install administrator components
+Our application will only have adminstrators who can view data and anonymous reporters who will log offenses, so we don't need to create a User model, just one for Administrators.
+* `rails g active_admin:install` will generate files for Administrators, including a migration to create the table
+
+### Add the Administrators table
+* `rake db:migrate`
+
+### Create a default administrator
+We'll only use this record for our development environment because the credentials are common knowledge.
+* `rake db:seed`
+admin@example.com/password
+
+## Integrate Active Admin with our application
+We want anybody to be able to create an offense, but we only want certain folks to be able to see and/or change offenses so we want to make sure that our create or report action doesn't require credentials, but everywhere else does.
+

--- a/workalong.md
+++ b/workalong.md
@@ -86,3 +86,9 @@ admin@example.com/password
 ## Integrate Active Admin with our application
 We want anybody to be able to create an offense, but we only want certain folks to be able to see and/or change offenses so we want to make sure that our create or report action doesn't require credentials, but everywhere else does.
 
+### Require authentication
+http://guides.rubyonrails.org/action_controller_overview.html#filters
+We've added `before_action :authenticate_admin_user!` to `ApplicationController`.  `before_action` is a filter and it references a method that Active Admin provides.  What we are doing here is telling Rails to make sure an admin user is signed in before executing _any_ `Controller` method.
+
+To allow some methods to be executed by anonymous users, we then use a skip filter (`skip_before_action`) and tell it to apply to `:new` and `:create` actions/methods.
+


### PR DESCRIPTION
Allowing `:create` and `:new` to occur without authentication. Also added documentation around Active Admin usage.
